### PR TITLE
Remove redundant Path reconstruction

### DIFF
--- a/OMOD-Framework/Framework.cs
+++ b/OMOD-Framework/Framework.cs
@@ -14,7 +14,7 @@ namespace OMODFramework
         internal byte OBMMFakeBuildNumber = 12;
         internal byte OBMMFakeCurrentOmodVersion = 4;
 
-        internal static string DLLPath { get; set; } = Path.Combine(Path.GetDirectoryName(typeof(Framework).Assembly.Location), "erri120.OMODFramework.dll");
+        internal static string DLLPath { get; set; } = typeof(Framework).Assembly.Location;
         internal static string TempDir { get; set; } = Path.Combine(Path.GetTempPath(), "obmm");
         #endregion
 


### PR DESCRIPTION
There's no need to separate the DLL path and then put it back together again.

This makes it slightly less hassle if you want to rename your DLL.