### PR TITLE
Fix default arguments in Select Case statements

### DIFF
--- a/OMOD-Framework/Scripting/obmmScriptHandler.cs
+++ b/OMOD-Framework/Scripting/obmmScriptHandler.cs
@@ -927,7 +927,7 @@ namespace OMODFramework.Scripting
             var result = new string[dialogResult.Length];
             for (var i = 0; i < dialogResult.Length; i++)
             {
-                result[i] = $"Case {Items[dialogResult[i]]}";
+                result[i] = $"Case {Items[dialogResult[i]].TrimStart(new[] { '|' })}";
             }
             return result;
         }


### PR DESCRIPTION
Fixes #10

Also, based on what the framework is doing (i.e. building an array of `Case item` strings to look for) I'm inclined to check if `Default` works as it's supposed to, too.